### PR TITLE
Fix Composer autoload.php file loading

### DIFF
--- a/bin/loxcan
+++ b/bin/loxcan
@@ -9,7 +9,13 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
-require_once __DIR__ . '/../vendor/autoload.php';
+if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
+    require_once __DIR__ . '/../vendor/autoload.php';
+} elseif (file_exists(__DIR__ . '/../../../autoload.php')) {
+    require_once __DIR__ . '/../../../autoload.php';
+} else {
+    die('Failed to load the autoload.php.');
+}
 
 $configs = [
     'commands.yaml',


### PR DESCRIPTION
Fix of the following error.

```
$ cd /app
$ composer require --dev siketyan/loxcan

$ ./vendor/bin/loxcan base head

Warning: require_once(/app/vendor/siketyan/loxcan/bin/../vendor/autoload.php): failed to open stream: No such file or directory in /app/vendor/siketyan/loxcan/bin/loxcan on line 12

Fatal error: require_once(): Failed opening required '/app/vendor/siketyan/loxcan/bin/../vendor/autoload.php' (include_path='.:/usr/local/lib/php') in /app/vendor/siketyan/loxcan/bin/loxcan on line 12
```