### PR TITLE
build: Use composite action instead of docker

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ runs:
         
         if [ "${{ inputs.report_enabled }}" = "true" ]; then
           export LOXCAN_REPORTER_GITHUB="1"
-          export LOXCAN_REPORTER_GITHUB_OWNER="${{ inputs.owner }}}"
+          export LOXCAN_REPORTER_GITHUB_OWNER="${{ inputs.owner }}"
           export LOXCAN_REPORTER_GITHUB_REPO="${{ inputs.repo }}"
           export LOXCAN_REPORTER_GITHUB_ISSUE_NUMBER="${{ inputs.issue_number }}"
           export LOXCAN_REPORTER_GITHUB_TOKEN="${{ inputs.token }}"

--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ runs:
   steps:
     - shell: bash
       run: |
-        composer global require --dev siketyan/loxcan:^0.7.2
+        pushd '${{ github.action_path }}' && composer i -n && popd
         
         if [ "${{ inputs.report_enabled }}" = "true" ]; then
           export LOXCAN_REPORTER_GITHUB="1"
@@ -48,4 +48,4 @@ runs:
         BRANCH_BASE="origin/${{ inputs.base }}"
         BRANCH_HEAD="${{ github.sha }}"
         
-        ~/.composer/vendor/bin/loxcan "${BRANCH_BASE}" "${BRANCH_HEAD}"
+        ${{ github.action_path }}/bin/loxcan "${BRANCH_BASE}" "${BRANCH_HEAD}"

--- a/action.yml
+++ b/action.yml
@@ -30,5 +30,22 @@ inputs:
     description: 'An OAuth token to access to the repository as a bot.'
     default: ${{ github.token }}
 runs:
-  using: 'docker'
-  image: 'docker://ghcr.io/siketyan/loxcan@sha256:6d9b332528755dfbf664606a94bdb7106a65cff620ed2c0bee51fcf134f87160'
+  using: 'composite'
+  steps:
+    - shell: bash
+      run: |
+        composer global require --dev siketyan/loxcan:^0.7.2
+        
+        if [ "${{ inputs.report_enabled }}" = "true" ]; then
+          export LOXCAN_REPORTER_GITHUB="1"
+          export LOXCAN_REPORTER_GITHUB_OWNER="${{ inputs.owner }}}"
+          export LOXCAN_REPORTER_GITHUB_REPO="${{ inputs.repo }}"
+          export LOXCAN_REPORTER_GITHUB_ISSUE_NUMBER="${{ inputs.issue_number }}"
+          export LOXCAN_REPORTER_GITHUB_TOKEN="${{ inputs.token }}"
+          export LOXCAN_REPORTER_GITHUB_USERNAME="github-actions[bot]"
+        fi
+        
+        BRANCH_BASE="origin/${{ inputs.base }}"
+        BRANCH_HEAD="${{ github.sha }}"
+        
+        ~/.composer/vendor/bin/loxcan "${BRANCH_BASE}" "${BRANCH_HEAD}"


### PR DESCRIPTION
Follow-up of #90 

We are experiencing that LoXcan fails in most GitHub hosted runners. As of today the runners have Git v2.40.1, but in the Docker image we have Git v2.30.2. This version mismatch causes corruption of the Git object files, then the action fails.

To resolve that, we need to use the installed version of Git on the host machine. This means we may not use Docker if the Git on the host is then newer than the Git in the Docker image. No data migration happen then.

This pull request propses to change this action to a composite action to use the Git on the runner. So no version mismatch will happen.